### PR TITLE
Prettyprint

### DIFF
--- a/odt_git_helper.py
+++ b/odt_git_helper.py
@@ -63,6 +63,9 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    if args.prettyprint and args.compress:
+        print 'Note: prettyprinting is only used when extracting the .odt file'
+
     if args.extract or (not args.extract and not args.compress):
         print 'Extract files'
         extractODT(args.directory, args.odt_file, args)

--- a/odt_git_helper.py
+++ b/odt_git_helper.py
@@ -26,31 +26,33 @@ def extractODT(path, zipName, args):
         zipf.extract(name, path)
     zipf.close()
 
-    if args.verbose:
-        print "Pretty xml generation"
-    for root, dirs, files in os.walk(path):
-        for file in files:
-            fileWPath = os.path.join(root, file)
-            if fileWPath[-3:] == "xml":
-                if args.verbose:
-                    print fileWPath
+    if args.prettyprint:
+        if args.verbose:
+            print "Pretty xml generation"
+        for root, dirs, files in os.walk(path):
+            for file in files:
+                fileWPath = os.path.join(root, file)
+                if fileWPath[-3:] == "xml":
+                    if args.verbose:
+                        print fileWPath
 
-                statinfo = os.stat(fileWPath)
-                if statinfo.st_size == 0:
-                    continue
+                    statinfo = os.stat(fileWPath)
+                    if statinfo.st_size == 0:
+                        continue
 
-                xmlFile = xml.dom.minidom.parse(fileWPath)
-                pretty_xml_as_string = xmlFile.toprettyxml()
+                    xmlFile = xml.dom.minidom.parse(fileWPath)
+                    pretty_xml_as_string = xmlFile.toprettyxml()
 
-                out_file = open(fileWPath,"w")
-                out_file.write(pretty_xml_as_string.encode('utf-8'))
-                out_file.close()
+                    out_file = open(fileWPath,"w")
+                    out_file.write(pretty_xml_as_string.encode('utf-8'))
+                    out_file.close()
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Extract/Create an odt file in/from a directory.')
 
     parser.add_argument("-v","--verbose", action='store_true', default=False, help="increase output verbosity")
+    parser.add_argument("-p","--prettyprint", action='store_true', default=False, help="prettyprint xml files")
 
     group = parser.add_mutually_exclusive_group()
     group.add_argument("-c", "--compress", action="store_true", default=False, help='compress into an .odt file')


### PR DESCRIPTION
Make prettyprint optional, because it is buggy. See:
https://stackoverflow.com/questions/14479656/empty-lines-while-using-minidom-toprettyxml

The simple solutions suggested to the stackoverflow question are not correct in all situations (eg. one may want to preserve newlines in some element values). A workaround is to get openoffice/libreoffice to generate pretty xmls:

> By default, content.xml is stored without formatting elements like indentation or line breaks to minimize the time for saving and opening the document. The use of indentations and line breaks can be activated in the Expert configuration by setting the property /org.openoffice.Office.Common/Save/Document PrettyPrinting to true.

(https://help.libreoffice.org/Common/XML_File_Formats#XML_file_structure)