### PR TITLE
fix print for python3

### DIFF
--- a/odt_git_helper.py
+++ b/odt_git_helper.py
@@ -68,9 +68,9 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     if args.prettyprint and args.compress:
-        print 'Note: prettyprinting is only used when extracting the .odt file'
+        print('Note: prettyprinting is only used when extracting the .odt file')
     if args.zlib and args.extract:
-        print 'Note: zlib compression is only used when compressing the files'
+        print('Note: zlib compression is only used when compressing the files')
 
     if args.extract or (not args.extract and not args.compress):
         print('Extract files')


### PR DESCRIPTION
Fix print parentheses for python3.

I started all the previous feature branches on top of your `master` and not on top of my first `python3-compat` branch, so I used python2 code for the two other branches. Sorry!

And thanks for the nice script :)